### PR TITLE
Make imagePullSecrets optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
+# Unreleased
 
+* Provide parameters for setting the origin of the busybox image which is used
+  as a part of the Stardog pod initialization (#60)
+  
 # 2.0.3 (2021-09-16)
 
 * Use Java G1 gc by default (#56)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add Stardog server start arguments to the values file (#66)
 * Provide parameters for setting the origin of the busybox image which is used
   as a part of the Stardog pod initialization (#60)
 * Create the tmpDir used by Stardog if it doesn't already exist. This can be useful when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Added the ability to add additional settings to the configmap of the stardog configmap
 * Add Stardog server start arguments to the values file (#66)
 * Provide parameters for setting the origin of the busybox image which is used
   as a part of the Stardog pod initialization (#60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 * Provide parameters for setting the origin of the busybox image which is used
   as a part of the Stardog pod initialization (#60)
-  
+* Create the tmpDir used by Stardog if it doesn't already exist. This can be useful when
+  placing the tmpDir onto the same volume as STARDOG_HOME (/var/opt/stardog). Note 
+  that it's critical not to choose a path within STARDOG_HOME that could conflict with a
+  database name. See the [values.yaml](charts/stardog/values.yaml) for details. (#62)
+
 # 2.0.3 (2021-09-16)
 
 * Use Java G1 gc by default (#56)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 2.0.3 (Unreleased)
+
+* Remove admin password from post-install job standard out (#48)
+
 # 2.0.2 (2021-06-09)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.5 (2022-06-07)
+
+* Patch the zookeeper dependency in stardog chart a result of change in the bitnami retention policy (#71)
+
 # 2.0.4 (2021-12-07)
 
 * Added the ability to add additional settings to the configmap of the stardog configmap (#50). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 2.0.4 (2021-12-07)
 
-* Added the ability to add additional settings to the configmap of the stardog configmap
+* Added the ability to add additional settings to the configmap of the stardog configmap (#50). 
 * Add Stardog server start arguments to the values file (#66)
 * Provide parameters for setting the origin of the busybox image which is used
   as a part of the Stardog pod initialization (#60)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 
+# 2.0.2 (2021-06-09)
+
+Features:
+* Allow user to set annotations and loadBalancerIP property of service (#46)
+* Supports tolerations for tainted nodes (#44)
+* Tune chart values and settings to improve startup time (#41)
+* Make podManagementPolicy configurable for Stardog statefulset (#39)
+
 # 2.0.1 (2020-12-14)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
-# 2.0.3 (Unreleased)
+# 2.0.3 (2021-09-16)
 
+* Use Java G1 gc by default (#56)
+* Set JVM active processor count to k8s cpu requests, default to 2 (#51)
 * Remove admin password from post-install job standard out (#48)
 
 # 2.0.2 (2021-06-09)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ must be running that version of Stardog or later. Please see the Stardog chart
 [README](https://github.com/stardog-union/helm-charts/blob/master/charts/stardog/README.md)
 for instructions on how to upgrade from version 1.x of the charts to version 2.
 
+We strongly recommend that the charts request at least 2 CPUs or more for Stardog.
+By default the Stardog chart requests 2 CPUs. This value can be configured in the
+`values.yaml` file.
+
 Prerequisites
 -------------
 

--- a/charts/stardog/Chart.lock
+++ b/charts/stardog/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   version: 5.5.1
-digest: sha256:50505e713c532691af6a8907b008b9e6a4dd5c5c6f3889ae72b82424f841ebcc
-generated: "2020-11-12T15:01:34.784401-06:00"
+digest: sha256:eaac5e300a586dd12a580e20c6f97618da1cf825e93950ad5447d327b1275c4c
+generated: "2022-06-06T17:02:33.115306-07:00"

--- a/charts/stardog/Chart.yaml
+++ b/charts/stardog/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 dependencies:
   - name: zookeeper
     version: 5.5.1
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     condition: zookeeper.enabled

--- a/charts/stardog/Chart.yaml
+++ b/charts/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stardog
 description: Helm chart to deploy Stardog Cluster and associated services
-version: 2.0.4
+version: 2.0.5
 appVersion: latest
 home: https://github.com/stardog-union/helm-charts
 icon: https://s3.amazonaws.com/stardog-logos.public/stardog-logo.png

--- a/charts/stardog/Chart.yaml
+++ b/charts/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stardog
 description: Helm chart to deploy Stardog Cluster and associated services
-version: 2.0.2
+version: 2.0.3
 appVersion: latest
 home: https://github.com/stardog-union/helm-charts
 icon: https://s3.amazonaws.com/stardog-logos.public/stardog-logo.png

--- a/charts/stardog/Chart.yaml
+++ b/charts/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stardog
 description: Helm chart to deploy Stardog Cluster and associated services
-version: 2.0.3
+version: 2.0.4
 appVersion: latest
 home: https://github.com/stardog-union/helm-charts
 icon: https://s3.amazonaws.com/stardog-logos.public/stardog-logo.png

--- a/charts/stardog/Chart.yaml
+++ b/charts/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: stardog
 description: Helm chart to deploy Stardog Cluster and associated services
-version: 2.0.1
+version: 2.0.2
 appVersion: latest
 home: https://github.com/stardog-union/helm-charts
 icon: https://s3.amazonaws.com/stardog-logos.public/stardog-logo.png

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -53,6 +53,7 @@ Configuration Parameters
 | `busybox.image.tag`                          | The Docker image tag for busybox image (used as a part of Stardog initialization) |
 | `busybox.image.username`                     | The Docker registry username for busybox image registry (used as a part of Stardog initialization) |
 | `busybox.image.password`                     | The Docker registry password for the busybox image registry (used as a part of Stardog initialization)  |
+| `additionalStardogProperties`                | Allow adding additional settings to stardog.properties file |
 
 The default values are specified in `values.yaml` as well as the required values for the ZooKeeper chart.
 

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -31,7 +31,8 @@ Configuration Parameters
 | `admin.password`                             | Stardog admin password |
 | `javaArgs`                                   | Java args for Stardog server |
 | `image.registry`                             | The Docker registry containing the Stardog image |
-| `image.repository`                           | The Docker image repostory containing the Stardog image  |
+| `image.repository`                           | The Docker image repository containing the Stardog image  |
+| `image.pullPolicy`                           | The Docker image pullPolicy for Stardog |
 | `image.tag`                                  | The Docker image tag for Stardog |
 | `image.username`                             | The Docker registry username |
 | `image.password`                             | The Docker registry password |
@@ -45,6 +46,12 @@ Configuration Parameters
 | `securityContext.runAsUser`                  | UID used by the Stardog container to run as non-root |
 | `securityContext.runAsGroup`                 | GID used by the Stardog container to run as non-root |
 | `securityContext.fsGroup`                    | GID for the volume mounts |
+| `busybox.image.registry`                     | The Docker registry containing the busybox image (used as a part of Stardog initialization) |
+| `busybox.image.repository`                   | The Docker image repository containing the busybox image (used as a part of Stardog initialization) |
+| `busybox.image.pullPolicy`                   | The Docker image pullPolicy for the busybox image (used as a part of Stardog initialization) |
+| `busybox.image.tag`                          | The Docker image tag for busybox image (used as a part of Stardog initialization) |
+| `busybox.image.username`                     | The Docker registry username for busybox image registry (used as a part of Stardog initialization) |
+| `busybox.image.password`                     | The Docker registry password for the busybox image registry (used as a part of Stardog initialization)  |
 
 The default values are specified in `values.yaml` as well as the required values for the ZooKeeper chart.
 

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -30,6 +30,7 @@ Configuration Parameters
 | `podManagementPolicy`                        | Set the pod startup policy - use `OrderedReady` (default) or `Parallel` |
 | `admin.password`                             | Stardog admin password |
 | `javaArgs`                                   | Java args for Stardog server |
+| `serverStartArgs`                            | Additional arguments for Stardog server start |
 | `image.registry`                             | The Docker registry containing the Stardog image |
 | `image.repository`                           | The Docker image repository containing the Stardog image  |
 | `image.pullPolicy`                           | The Docker image pullPolicy for Stardog |

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -40,7 +40,7 @@ Configuration Parameters
 | `persistence.size`                           | The size of volume for Stardog home |
 | `ports.server`                               | The port to expose Stardog server |
 | `ports.sql`                                  | The port to expose Stardog BI server |
-| `tmpDir`                                     | The directory to use for Stardog tmp space |
+| `tmpDir`                                     | The directory to use for Stardog tmp space. If you choose to place this in STARDOG_HOME (/var/opt/stardog) for performance reasons, ensure that it does not conflict with any possible database names. For example, a good choice might be /var/opt/stardog/tmp-4646E7B662A7. If the directory does not exist it will be created. |
 | `log4jConfig.override`                       | Whether to override the default log4j config |
 | `log4jConfig.content`                        | The new log4j configuration |
 | `securityContext.runAsUser`                  | UID used by the Stardog container to run as non-root |

--- a/charts/stardog/README.md
+++ b/charts/stardog/README.md
@@ -27,6 +27,7 @@ Configuration Parameters
 | `namespaceOverride`                          | The k8s namespace for the Stardog deployment (single node only) |
 | `cluster.enabled`                            | Enable Stardog Cluster |
 | `replicaCount`                               | The number of replicas in Stardog Cluster |
+| `podManagementPolicy`                        | Set the pod startup policy - use `OrderedReady` (default) or `Parallel` |
 | `admin.password`                             | Stardog admin password |
 | `javaArgs`                                   | Java args for Stardog server |
 | `image.registry`                             | The Docker registry containing the Stardog image |

--- a/charts/stardog/files/utils.sh
+++ b/charts/stardog/files/utils.sh
@@ -54,3 +54,18 @@ function change_pw {
     fi
     )
 }
+
+function make_temp {
+    (
+    set +e
+    TEMP_PATH=${1}
+
+    if [ ! -d "$TEMP_PATH" ]; then
+      mkdir -p $TEMP_PATH
+      if [ $? -ne 0 ]; then
+        echo "Could not create stardog tmp directory ${TEMP_PATH}" >&2
+        return 1
+      fi
+    fi
+    )
+}

--- a/charts/stardog/files/utils.sh
+++ b/charts/stardog/files/utils.sh
@@ -18,8 +18,6 @@ function wait_for_start {
       curl -v  http://${HOST}:${PORT}/admin/healthcheck
       RC=$?
     done
-    # Give it a second to finish starting up
-    sleep 20
 
     return 0
     )

--- a/charts/stardog/files/utils.sh
+++ b/charts/stardog/files/utils.sh
@@ -25,9 +25,11 @@ function wait_for_start {
 
 function change_pw {
     (
-    set +e
+    set +ex
     HOST=${1}
     PORT=${2}
+
+    echo "/opt/stardog/bin/stardog-admin --server http://${HOST}:${PORT} user passwd -N xxxxxxxxxxxxxx"
     NEW_PW=$(cat /etc/stardog-password/adminpw)
     /opt/stardog/bin/stardog-admin --server http://${HOST}:${PORT} user passwd -N ${NEW_PW}
     if [[ $? -eq 0 ]];

--- a/charts/stardog/templates/_helpers.tpl
+++ b/charts/stardog/templates/_helpers.tpl
@@ -28,6 +28,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.registry (printf "%s:%s" .Values.image.username .Values.image.password | b64enc) | b64enc }}
 {{- end -}}
 
+{{- define "imagePullSecretBusybox" -}}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.busybox.image.registry (printf "%s:%s" .Values.busybox.image.username .Values.busybox.image.password | b64enc) | b64enc }}
+{{- end -}}
+
 {{/*
 Return Stardog namespace to use
 */}}

--- a/charts/stardog/templates/configmap.yaml
+++ b/charts/stardog/templates/configmap.yaml
@@ -32,3 +32,4 @@ data:
     pack.zookeeper.address={{ if .Values.zookeeper.enabled }}{{- template "zkservers" . }}{{ else }}{{ .Values.zookeeper.addresses }}{{ end }}
     pack.node.join.retry.count=15
     pack.node.join.retry.delay=1m
+  {{- .Values.additionalStardogProperties | nindent 4 }}

--- a/charts/stardog/templates/secret-image-busybox.yaml
+++ b/charts/stardog/templates/secret-image-busybox.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.busybox.image.username .Values.busybox.image.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-image-busybox-pull-secret
+  namespace: {{ include "stardog.namespace" . }}
+  labels:
+    helm.sh/chart: {{ include "stardog.chart" . }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecretBusybox" .  }}
+{{- end }}

--- a/charts/stardog/templates/service.yaml
+++ b/charts/stardog/templates/service.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: {{ .Values.ports.server }}
@@ -19,5 +23,8 @@ spec:
     name: sql
   {{- end }}
   type: {{ .Values.service.type }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   selector:
     app: {{ include "stardog.fullname" . }}

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -28,6 +28,9 @@ spec:
         app.kubernetes.io/version: {{ .Chart.AppVersion }}
         app.kubernetes.io/component: server
     spec:
+      {{- with .Values.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}
 {{ if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -121,7 +121,7 @@ spec:
         - name: STARDOG_PROPERTIES
           value: "/etc/stardog-conf/stardog.properties"
         - name: STARDOG_SERVER_JAVA_ARGS
-          value: "-Djava.io.tmpdir={{ .Values.tmpDir }} {{ .Values.javaArgs }}"
+          value: "-XX:ActiveProcessorCount={{ .Values.resources.requests.cpu }}  -Djava.io.tmpdir={{ .Values.tmpDir }} {{ .Values.javaArgs }}"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         command:

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -125,6 +125,8 @@ spec:
           value: "-XX:ActiveProcessorCount={{ .Values.resources.requests.cpu }}  -Djava.io.tmpdir={{ .Values.tmpDir }} {{ .Values.javaArgs }}"
         - name: STARDOG_PERF_JAVA_ARGS
           value: "{{ .Values.stardogPerfJavaArgs }}"
+        - name: STARDOG_TMP_PATH
+          value: "{{ .Values.tmpDir }}"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         command:
@@ -133,6 +135,7 @@ spec:
         - |
           set -ex
           {{ .Files.Get "files/utils.sh" | indent 10 }}
+          make_temp ${STARDOG_TMP_PATH}
           /opt/stardog/bin/stardog-admin server start --foreground --port ${PORT} --home ${STARDOG_HOME}
         livenessProbe:
           httpGet:

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -16,6 +16,7 @@ spec:
       app: {{ include "stardog.fullname" . }}
   serviceName: {{ include "stardog.fullname" . }}
   replicas: {{ .Values.replicaCount }}
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
   template:
     metadata:
       labels:

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -122,6 +122,8 @@ spec:
           value: "/etc/stardog-conf/stardog.properties"
         - name: STARDOG_SERVER_JAVA_ARGS
           value: "-XX:ActiveProcessorCount={{ .Values.resources.requests.cpu }}  -Djava.io.tmpdir={{ .Values.tmpDir }} {{ .Values.javaArgs }}"
+        - name: STARDOG_PERF_JAVA_ARGS
+          value: "{{ .Values.stardogPerfJavaArgs }}"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         command:

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -62,7 +62,8 @@ spec:
 {{ if .Values.cluster.enabled }}
       initContainers:
       - name: wait-for-zk
-        image: busybox
+        image: {{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}
+        imagePullPolicy: {{ .Values.busybox.image.pullPolicy }}
         command:
         - /bin/sh
         - -c
@@ -158,6 +159,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-image-pull-secret
+      - name: {{ .Release.Name }}-image-busybox-pull-secret
       volumes:
       - name: stardog-license
         secret:

--- a/charts/stardog/templates/statefulset.yaml
+++ b/charts/stardog/templates/statefulset.yaml
@@ -127,6 +127,8 @@ spec:
           value: "{{ .Values.stardogPerfJavaArgs }}"
         - name: STARDOG_TMP_PATH
           value: "{{ .Values.tmpDir }}"
+        - name: STARDOG_SERVER_START_ARGS
+          value: "{{ .Values.serverStartArgs }}"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         command:
@@ -136,7 +138,7 @@ spec:
           set -ex
           {{ .Files.Get "files/utils.sh" | indent 10 }}
           make_temp ${STARDOG_TMP_PATH}
-          /opt/stardog/bin/stardog-admin server start --foreground --port ${PORT} --home ${STARDOG_HOME}
+          /opt/stardog/bin/stardog-admin server start --foreground --port ${PORT} --home ${STARDOG_HOME} ${STARDOG_SERVER_START_ARGS}
         livenessProbe:
           httpGet:
             path: /admin/alive

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -26,6 +26,9 @@ terminationGracePeriodSeconds: 300
 # Java args for Stardog server
 javaArgs: "-Xmx2g -Xms2g -XX:MaxDirectMemorySize=1g"
 
+# Additional arguments passed to Stardog at server start
+serverStartArgs: ""
+
 # Stardog Java perf args, e.g. for changing Java gc
 stardogPerfJavaArgs: "-XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UseG1GC -XX:+UseCompressedOops"
 

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -117,6 +117,12 @@ readinessProbe:
   periodSeconds: 5
   timeoutSeconds: 3
 
+# Add additional settings to the stardog config file. e.g.
+# additionalStardogProperties: |
+#   logging.slow_query.enabled=true
+#   logging.slow_query.time=10s
+additionalStardogProperties: |
+
 # The busybox image is used as light weight init container as a part of
 # stardog initialization.
 busybox:
@@ -165,4 +171,3 @@ zookeeper:
 #    failureThreshold: 6
 #    successThreshold: 1
 #    probeCommandTimeout: 2
-

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -110,6 +110,16 @@ readinessProbe:
   periodSeconds: 5
   timeoutSeconds: 3
 
+# The busybox image is used as light weight init container as a part of
+# stardog initialization.
+busybox:
+  image:
+    registry: https://registry.hub.docker.com/v1/repositories
+    repository: busybox
+    tag: stable
+    pullPolicy: IfNotPresent
+    # username:
+    # password:
 
 # Settings to use for the ZooKeeper chart that Stardog depends on.
 # The full set of options can be found on the bitname ZK chart:
@@ -148,3 +158,4 @@ zookeeper:
 #    failureThreshold: 6
 #    successThreshold: 1
 #    probeCommandTimeout: 2
+

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -7,13 +7,13 @@ replicaCount: 3
 
 # How to start the pods - use OrderedReady to use the default behavior of
 # starting each pod one at a time or use Parallel to start them all at once
-podManagementPolicy: OrderedReady
+podManagementPolicy: Parallel
 
 # The number of seconds the post install job will wait for Stardog to
 # start. This includes the total time to launch the cluster in k8s,
 # including ZooKeeper. Consider increasing it for k8s providers that
 # have slower resource provisioning.
-waitForStartSeconds: 600
+waitForStartSeconds: 300
 
 cluster:
   # Start Stardog as a cluster
@@ -94,7 +94,7 @@ livenessProbe:
 # Stardog readiness probe settings. Consider increasing initialDelaySeconds when using nodes with
 # K8S nodes with limited CPUs. It is not generally required to modify periodSeconds and timeoutSeconds.
 readinessProbe:
-  initialDelaySeconds: 90
+  initialDelaySeconds: 15
   periodSeconds: 5
   timeoutSeconds: 3
 

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -41,7 +41,11 @@ ports:
   server: 5820
   # sql: 5806
 
-# The location Stardog will use for temporary space (i.e. java.io.tmpdir)
+# The location Stardog will use for temporary space (i.e. java.io.tmpdir).
+# If you choose to place this in STARDOG_HOME (/var/opt/stardog) for performance
+# reasons, ensure that it does not conflict with any possible database names.
+# For example, a good choice might be /var/opt/stardog/tmp-4646E7B662A7.
+# If the directory does not exist it will be created.
 tmpDir: /tmp
 
 # The initial password for the Stardog admin user

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -26,6 +26,9 @@ terminationGracePeriodSeconds: 300
 # Java args for Stardog server
 javaArgs: "-Xmx2g -Xms2g -XX:MaxDirectMemorySize=1g"
 
+# Stardog Java perf args, e.g. for changing Java gc
+stardogPerfJavaArgs: "-XX:SoftRefLRUPolicyMSPerMB=1 -XX:+UseG1GC -XX:+UseCompressedOops"
+
 # The service type to use for Stardog ports
 service:
   type: LoadBalancer

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -69,10 +69,12 @@ tolerations: []
 
 antiAffinity: requiredDuringSchedulingIgnoredDuringExecution
 
-resources: {}
-#  requests:
-#    cpu: 1
-#    memory: 4Gi
+# Stardog should have at least 2 CPUs. The CPU request value is used to set
+# -XX:ActiveProcessorCount=N for the JVM.
+resources:
+  requests:
+    cpu: 2
+    memory: 4Gi
 #  limits:
 #    cpu: 2
 #    memory: 6Gi

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -5,6 +5,10 @@
 # The number of Stardog replicas to deploy in the cluster
 replicaCount: 3
 
+# How to start the pods - use OrderedReady to use the default behavior of
+# starting each pod one at a time or use Parallel to start them all at once
+podManagementPolicy: OrderedReady
+
 # The number of seconds the post install job will wait for Stardog to
 # start. This includes the total time to launch the cluster in k8s,
 # including ZooKeeper. Consider increasing it for k8s providers that

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -60,6 +60,11 @@ persistence:
   size: 5Gi
 
 nodeSelector: {}
+tolerations: []
+#  - key: key1
+#    value: value1
+#    effect: NoSchedule
+
 antiAffinity: requiredDuringSchedulingIgnoredDuringExecution
 
 resources: {}

--- a/charts/stardog/values.yaml
+++ b/charts/stardog/values.yaml
@@ -29,6 +29,8 @@ javaArgs: "-Xmx2g -Xms2g -XX:MaxDirectMemorySize=1g"
 # The service type to use for Stardog ports
 service:
   type: LoadBalancer
+  annotations: {}
+  # loadBalancerIP: 0.0.0.0
 
 # The server port is the port to expose the Stardog server
 # The sql port is the port to expose Stardog's business intelligence server

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -133,7 +133,9 @@ function check_expected_num_stardog_pods() {
 	echo "Checking if there are the expected number of Stardog pods (${num_stardogs})"
 
 	FOUND_STARDOGS=$(kubectl -n ${NAMESPACE} get pods -o wide | grep "${HELM_RELEASE_NAME}-stardog-" | wc -l)
-	if [ ${FOUND_STARDOGS} -ne ${num_stardogs} ]; then
+	# the post install pod for stardog will match here too, but it may disappear before this check runs,
+	# so either ${num_stardogs} or ${num_stardogs} + 1 is fine here
+	if [[ ${FOUND_STARDOGS} -lt ${num_stardogs} || ${FOUND_STARDOGS} -gt $((num_stardogs+1)) ]]; then
 		echo "Found ${FOUND_STARDOGS} but expected ${num_stardogs} Stardog pods, exiting"
 		exit 1
 	fi


### PR DESCRIPTION
Make imagePullSecrets optional, in order to make both the busybox and main stardog image pull secrets optional I need to pull the latest from stardog-union:develop. Then I can re-apply my changes which doesn't presume image pull secrets are always set.